### PR TITLE
동행복권 로또 구매 이력 조회 기능 분리

### DIFF
--- a/src/main/java/com/lottog/purchaser/service/PurchasableCountService.java
+++ b/src/main/java/com/lottog/purchaser/service/PurchasableCountService.java
@@ -1,0 +1,86 @@
+package com.lottog.purchaser.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.springframework.stereotype.Service;
+
+import java.text.MessageFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class PurchasableCountService {
+
+    private static final String URL_PURCHASED_LIST = "https://dhlottery.co.kr/myPage.do?method=lottoBuyList&searchStartDate={0}&searchEndDate={1}&lottoId=LO40&winGrade=2";
+
+    private final SeleniumService seleniumService;
+
+    /**
+     * 당 회차 구매 이력 조회를 통한 구매가능 매수 반환 method
+     * @return 구매가능 매수
+     */
+    public Integer getPurchasableCount() {
+        try {
+            String css;
+            int pc = 5; //온라인 구매 제한 = 5게임
+
+            //당 회차(일요일 ~ 토요일) 구매내역 확인창 오픈
+            MessageFormat iframeURL = new MessageFormat(URL_PURCHASED_LIST);
+            String startDt = getPreviousSunday(); //당 회차 시작일
+            String endDt = getNextSaturday(); //당 회차 발표일
+            seleniumService.openUrl(iframeURL.format(new Object[] {startDt, endDt}));
+
+            //구매 내역 테이블 조회
+            css = "body > table > tbody > tr";
+            List<WebElement> purchaseElements = seleniumService.getElementsByCssSelector(css);
+            for (WebElement e : purchaseElements) {
+                if (e.getText().equals("조회 결과가 없습니다.")) break; //구매 내역이 전혀 없다면, loop exit
+
+                String gameResult = e.findElement(By.cssSelector("td:nth-child(6)")).getText(); //당첨결과 column
+                int purchaseCnt = Integer.parseInt(e.findElement(By.cssSelector("td:nth-child(5)")).getText()); //구입매수 column
+
+                //미추첨 내역은 당 회차 구매내역이므로 잔여 구매가능 매수에서 차감
+                if (gameResult.equals("미추첨")) {
+                    pc -= purchaseCnt;
+                }
+            }
+
+            return pc;
+
+        } catch (Exception e) {
+            seleniumService.closeWebDriver();
+
+            log.error("=== getPurchasableCount() occurred error - {}", e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * 당 회차 시작일 반환
+     * @return 당 회차 시작일 (yyyyMMdd)
+     */
+    private String getPreviousSunday() {
+        LocalDate today = LocalDate.now();
+
+        //오늘의 DayOfWeek 더해준다. (오늘을 포함한 과거의 가장 가까운 일요일) - 회차 시작일
+        return today.minusDays(today.getDayOfWeek().getValue())
+                .format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+    }
+
+    /**
+     * 당 회차 발표일 반환
+     * @return 당 회차 발표일 (yyyyMMdd)
+     */
+    private String getNextSaturday() {
+        LocalDate today = LocalDate.now();
+
+        //토요일이 6 이므로, 오늘의 DayOfWeek 빼준다. (오늘을 포함한 미래의 가장 가까운 토요일) - 회차 종료일
+        return today.plusDays(6 - today.getDayOfWeek().getValue())
+                .format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+    }
+}

--- a/src/main/java/com/lottog/purchaser/service/SeleniumService.java
+++ b/src/main/java/com/lottog/purchaser/service/SeleniumService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Duration;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -112,6 +113,26 @@ public class SeleniumService {
 
             } catch (TimeoutException e) {
                 log.warn("=== [WARNING] Css selector `{}` not found, retrying... ({}/{})", css, (i + 1), SELENIUM_RETRY_CNT);
+            }
+        }
+
+        throw new NoSuchElementException("Css selector `" + css + "` not found.");
+    }
+
+    /**
+     * Get web element by CSS selector (다중 객체)
+     * @param css CSS selector
+     * @return List of web element
+     */
+    public List<WebElement> getElementsByCssSelector(String css) {
+        for (int i = 0; i < SELENIUM_RETRY_CNT; i++) {
+            try {
+                return webDriverWait.until(
+                        ExpectedConditions.presenceOfAllElementsLocatedBy(By.cssSelector(css))
+                );
+
+            } catch (TimeoutException e) {
+                log.warn("=== Css selector `{}` not found, retrying... ({}/{})", css, (i + 1), SELENIUM_RETRY_CNT);
             }
         }
 


### PR DESCRIPTION
이번 PR 은 로또 구매 이력 조회 기능 분리 관련 작업이다. (#10 과 연관)

기존에 로그인 시, `예치금 잔액 조회 + 당 회차 구매이력 조회를 통한 구매 가능 매수 조회` 였다.

최초 동행복권 로그인 시에만, 두 가지 로직을 통해 조회하면 된다.
예치금 잔액 조회는 별도로 새로고침 하거나, 예치금 입금 후 새로고침 하는 과정에서 사용된다.

성능 향상을 위해 method 를 분리했다.

This closes #8 