### PR TITLE
동행복권 예치금 잔액 조회 기능 분리

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Qualifier

--- a/src/main/java/com/lottog/purchaser/config/AppConfig.java
+++ b/src/main/java/com/lottog/purchaser/config/AppConfig.java
@@ -1,0 +1,16 @@
+package com.lottog.purchaser.config;
+
+import com.lottog.purchaser.dto.request.LoginRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+@Configuration
+public class AppConfig {
+
+    @Bean("loginInfoMap")
+    public ConcurrentHashMap<String, LoginRequest> loginInfoMap() {
+        return new ConcurrentHashMap<>();
+    }
+}

--- a/src/main/java/com/lottog/purchaser/controller/DepositController.java
+++ b/src/main/java/com/lottog/purchaser/controller/DepositController.java
@@ -1,0 +1,56 @@
+package com.lottog.purchaser.controller;
+
+import com.lottog.purchaser.dto.response.ErrorResponse;
+import com.lottog.purchaser.dto.response.LoginResponse;
+import com.lottog.purchaser.service.DepositService;
+import com.lottog.purchaser.service.LoginService;
+import com.lottog.purchaser.service.SeleniumService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+public class DepositController {
+
+    private final SeleniumService seleniumService;
+
+    private final LoginService loginService;
+
+    private final DepositService depositService;
+
+    @ResponseBody
+    @GetMapping("/deposit")
+    public ResponseEntity<?> getDeposit(String id) {
+        try {
+            //로그인 처리
+            LoginResponse loginResponse = loginService.login(id);
+
+            //로그인 실패 시, 결과 반환 처리
+            if (!loginResponse.success()) {
+                return ResponseEntity.ok(loginResponse);
+            }
+
+            Long deposit = depositService.getDeposit();
+
+            return ResponseEntity.ok(Map.of("deposit", deposit));
+
+        } catch (Exception e) {
+            log.error("=== getDeposit() occurred error - {}", e.getMessage());
+            ErrorResponse response = ErrorResponse.status500("getDeposit() - 오류가 발생했습니다. (id = " + id + ") - " + e.getMessage());
+
+            return ResponseEntity
+                    .status(response.status())
+                    .body(response);
+
+        } finally {
+            seleniumService.closeWebDriver();
+        }
+    }
+}

--- a/src/main/java/com/lottog/purchaser/controller/LoginController.java
+++ b/src/main/java/com/lottog/purchaser/controller/LoginController.java
@@ -2,32 +2,70 @@ package com.lottog.purchaser.controller;
 
 import com.lottog.purchaser.dto.request.LoginRequest;
 import com.lottog.purchaser.dto.response.ErrorResponse;
+import com.lottog.purchaser.dto.response.LoginResponse;
+import com.lottog.purchaser.dto.response.UserInfoResponse;
 import com.lottog.purchaser.service.LoginService;
+import com.lottog.purchaser.service.DepositService;
+import com.lottog.purchaser.service.PurchasableCountService;
+import com.lottog.purchaser.service.SeleniumService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RequiredArgsConstructor
 @RestController
 public class LoginController {
 
+    private final SeleniumService seleniumService;
+
     private final LoginService loginService;
+
+    private final DepositService depositService;
+
+    private final PurchasableCountService purchasableCountService;
 
     @ResponseBody
     @PostMapping("login")
     public ResponseEntity<?> login(@RequestBody LoginRequest request) {
         try {
-            return ResponseEntity.ok(loginService.login(request));
+            //로그인 처리
+            LoginResponse loginResponse = loginService.login(request);
+
+            //로그인 실패 시, 결과 반환 처리
+            if (!loginResponse.success()) {
+                return ResponseEntity.ok(loginResponse);
+            }
+
+            //사용자 정보 (예치금 잔액, 구매 가능 게임 수) 조회
+            Long deposit = depositService.getDeposit();
+            Integer purchasableCount = purchasableCountService.getPurchasableCount();
+
+            UserInfoResponse response;
+
+            if (purchasableCount == 0) {
+                response = UserInfoResponse.fail("더 이상 구매할 수 없습니다.", deposit, purchasableCount);
+            } else {
+                response = UserInfoResponse.ok(deposit, purchasableCount);
+            }
+
+            //결과 반환
+            return ResponseEntity.ok(response);
 
         } catch (Exception e) {
+            log.error("=== login() occurred error - {}", e.getMessage());
             ErrorResponse response = ErrorResponse.status500("login() - 오류가 발생했습니다. (id = " + request.id() + ") - " + e.getMessage());
 
             return ResponseEntity
                     .status(response.status())
                     .body(response);
+
+        } finally {
+            seleniumService.closeWebDriver();
         }
     }
 }

--- a/src/main/java/com/lottog/purchaser/dto/response/LoginResponse.java
+++ b/src/main/java/com/lottog/purchaser/dto/response/LoginResponse.java
@@ -1,18 +1,15 @@
 package com.lottog.purchaser.dto.response;
 
-import org.springframework.http.HttpStatus;
-
 public record LoginResponse(
-        HttpStatus status,
         Boolean success,
         String message
 ) {
 
     public static LoginResponse ok() {
-        return new LoginResponse(HttpStatus.OK, true, null);
+        return new LoginResponse(true, null);
     }
 
     public static LoginResponse fail(String message) {
-        return new LoginResponse(HttpStatus.OK, false, message);
+        return new LoginResponse(false, message);
     }
 }

--- a/src/main/java/com/lottog/purchaser/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/lottog/purchaser/dto/response/UserInfoResponse.java
@@ -1,0 +1,17 @@
+package com.lottog.purchaser.dto.response;
+
+public record UserInfoResponse(
+        Boolean purchasable,
+        String message,
+        Long deposit,
+        Integer pc //purchasable count
+) {
+
+    public static UserInfoResponse ok(Long deposit, Integer pc) {
+        return new UserInfoResponse(true, null, deposit, pc);
+    }
+
+    public static UserInfoResponse fail(String message, Long deposit, Integer pc) {
+        return new UserInfoResponse(false, message, deposit, pc);
+    }
+}

--- a/src/main/java/com/lottog/purchaser/service/DepositService.java
+++ b/src/main/java/com/lottog/purchaser/service/DepositService.java
@@ -1,0 +1,36 @@
+package com.lottog.purchaser.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class DepositService {
+
+    private final SeleniumService seleniumService;
+
+    public Long getDeposit() {
+        try {
+            String css;
+
+            //예치금 잔액 조회
+            css = "#container > div > div.myinfo_content.account > div.deposit > span > strong";
+
+            //예치금 잔액 반환
+            return Long.parseLong(
+                    seleniumService
+                            .getElementByCssSelector(css)
+                            .getText()
+                            .replaceAll("[^0-9]", "")
+            );
+
+        } catch (Exception e) {
+            seleniumService.closeWebDriver();
+
+            log.error("=== deposit() occurred error - {}", e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
이번 PR 은 예치금 잔액 조회 기능 분리 관련 작업이다. (#8 과 연관)

기존에 로그인 시, `예치금 잔액 조회 + 당 회차 구매이력 조회를 통한 구매 가능 매수 조회` 였다.

최초 동행복권 로그인 시에만, 두 가지 로직을 통해 조회하면 된다.
예치금 잔액 조회는 별도로 새로고침 하거나, 예치금 입금 후 새로고침 하는 과정에서 사용된다.

불필요한 작업을 제외하고, 성능 향상을 위해 method 를 분리했다.

This closes #10 