### PR TITLE
rename project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ configurations {
 }
 
 bootJar {
-    archiveFileName = 'lottery-purchaser.jar'
+    archiveFileName = 'lottery-buyer.jar'
 }
 
 repositories {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'lottery-purchaser'
+rootProject.name = 'lottery-buyer'

--- a/src/main/java/com/lottog/buyer/LotteryBuyerApplication.java
+++ b/src/main/java/com/lottog/buyer/LotteryBuyerApplication.java
@@ -1,13 +1,13 @@
-package com.lottog.purchaser;
+package com.lottog.buyer;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class LotteryPurchaserApplication {
+public class LotteryBuyerApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(LotteryPurchaserApplication.class, args);
+        SpringApplication.run(LotteryBuyerApplication.class, args);
     }
 
 }

--- a/src/main/java/com/lottog/buyer/config/AppConfig.java
+++ b/src/main/java/com/lottog/buyer/config/AppConfig.java
@@ -1,6 +1,6 @@
-package com.lottog.purchaser.config;
+package com.lottog.buyer.config;
 
-import com.lottog.purchaser.dto.request.LoginRequest;
+import com.lottog.buyer.dto.request.LoginRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/src/main/java/com/lottog/buyer/controller/CustomErrorController.java
+++ b/src/main/java/com/lottog/buyer/controller/CustomErrorController.java
@@ -1,6 +1,6 @@
-package com.lottog.purchaser.controller;
+package com.lottog.buyer.controller;
 
-import com.lottog.purchaser.dto.response.ErrorResponse;
+import com.lottog.buyer.dto.response.ErrorResponse;
 import org.springframework.boot.web.servlet.error.ErrorController;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/com/lottog/buyer/controller/DepositController.java
+++ b/src/main/java/com/lottog/buyer/controller/DepositController.java
@@ -1,11 +1,11 @@
-package com.lottog.purchaser.controller;
+package com.lottog.buyer.controller;
 
-import com.lottog.purchaser.dto.request.PaymentRequest;
-import com.lottog.purchaser.dto.response.ErrorResponse;
-import com.lottog.purchaser.dto.response.LoginResponse;
-import com.lottog.purchaser.service.LoginService;
-import com.lottog.purchaser.service.DepositService;
-import com.lottog.purchaser.service.SeleniumService;
+import com.lottog.buyer.dto.request.PaymentRequest;
+import com.lottog.buyer.dto.response.ErrorResponse;
+import com.lottog.buyer.dto.response.LoginResponse;
+import com.lottog.buyer.service.LoginService;
+import com.lottog.buyer.service.DepositService;
+import com.lottog.buyer.service.SeleniumService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/lottog/buyer/controller/LoginController.java
+++ b/src/main/java/com/lottog/buyer/controller/LoginController.java
@@ -1,13 +1,13 @@
-package com.lottog.purchaser.controller;
+package com.lottog.buyer.controller;
 
-import com.lottog.purchaser.dto.request.LoginRequest;
-import com.lottog.purchaser.dto.response.ErrorResponse;
-import com.lottog.purchaser.dto.response.LoginResponse;
-import com.lottog.purchaser.dto.response.UserInfoResponse;
-import com.lottog.purchaser.service.LoginService;
-import com.lottog.purchaser.service.DepositService;
-import com.lottog.purchaser.service.PurchasableCountService;
-import com.lottog.purchaser.service.SeleniumService;
+import com.lottog.buyer.dto.request.LoginRequest;
+import com.lottog.buyer.dto.response.ErrorResponse;
+import com.lottog.buyer.dto.response.LoginResponse;
+import com.lottog.buyer.dto.response.UserInfoResponse;
+import com.lottog.buyer.service.LoginService;
+import com.lottog.buyer.service.DepositService;
+import com.lottog.buyer.service.PurchasableCountService;
+import com.lottog.buyer.service.SeleniumService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/lottog/buyer/dto/request/LoginRequest.java
+++ b/src/main/java/com/lottog/buyer/dto/request/LoginRequest.java
@@ -1,4 +1,4 @@
-package com.lottog.purchaser.dto.request;
+package com.lottog.buyer.dto.request;
 
 public record LoginRequest(
         String id,

--- a/src/main/java/com/lottog/buyer/dto/request/PaymentRequest.java
+++ b/src/main/java/com/lottog/buyer/dto/request/PaymentRequest.java
@@ -1,4 +1,4 @@
-package com.lottog.purchaser.dto.request;
+package com.lottog.buyer.dto.request;
 
 public record PaymentRequest(
         String id

--- a/src/main/java/com/lottog/buyer/dto/response/ErrorResponse.java
+++ b/src/main/java/com/lottog/buyer/dto/response/ErrorResponse.java
@@ -1,4 +1,4 @@
-package com.lottog.purchaser.dto.response;
+package com.lottog.buyer.dto.response;
 
 import org.springframework.http.HttpStatus;
 

--- a/src/main/java/com/lottog/buyer/dto/response/LoginResponse.java
+++ b/src/main/java/com/lottog/buyer/dto/response/LoginResponse.java
@@ -1,4 +1,4 @@
-package com.lottog.purchaser.dto.response;
+package com.lottog.buyer.dto.response;
 
 public record LoginResponse(
         Boolean success,

--- a/src/main/java/com/lottog/buyer/dto/response/PaymentResponse.java
+++ b/src/main/java/com/lottog/buyer/dto/response/PaymentResponse.java
@@ -1,4 +1,4 @@
-package com.lottog.purchaser.dto.response;
+package com.lottog.buyer.dto.response;
 
 public record PaymentResponse(
         String name,

--- a/src/main/java/com/lottog/buyer/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/lottog/buyer/dto/response/UserInfoResponse.java
@@ -1,4 +1,4 @@
-package com.lottog.purchaser.dto.response;
+package com.lottog.buyer.dto.response;
 
 public record UserInfoResponse(
         Boolean purchasable,

--- a/src/main/java/com/lottog/buyer/service/DepositService.java
+++ b/src/main/java/com/lottog/buyer/service/DepositService.java
@@ -1,6 +1,6 @@
-package com.lottog.purchaser.service;
+package com.lottog.buyer.service;
 
-import com.lottog.purchaser.dto.response.PaymentResponse;
+import com.lottog.buyer.dto.response.PaymentResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;

--- a/src/main/java/com/lottog/buyer/service/LoginService.java
+++ b/src/main/java/com/lottog/buyer/service/LoginService.java
@@ -1,7 +1,7 @@
-package com.lottog.purchaser.service;
+package com.lottog.buyer.service;
 
-import com.lottog.purchaser.dto.request.LoginRequest;
-import com.lottog.purchaser.dto.response.LoginResponse;
+import com.lottog.buyer.dto.request.LoginRequest;
+import com.lottog.buyer.dto.response.LoginResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.WebElement;

--- a/src/main/java/com/lottog/buyer/service/PurchasableCountService.java
+++ b/src/main/java/com/lottog/buyer/service/PurchasableCountService.java
@@ -1,4 +1,4 @@
-package com.lottog.purchaser.service;
+package com.lottog.buyer.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/lottog/buyer/service/SeleniumService.java
+++ b/src/main/java/com/lottog/buyer/service/SeleniumService.java
@@ -1,6 +1,6 @@
-package com.lottog.purchaser.service;
+package com.lottog.buyer.service;
 
-import com.lottog.purchaser.dto.response.LoginResponse;
+import com.lottog.buyer.dto.response.LoginResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.*;
 import org.openqa.selenium.chrome.ChromeOptions;

--- a/src/test/java/com/lottog/buyer/LotteryBuyerApplicationTests.java
+++ b/src/test/java/com/lottog/buyer/LotteryBuyerApplicationTests.java
@@ -1,10 +1,10 @@
-package com.lottog.purchaser;
+package com.lottog.buyer;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class LotteryPurchaserApplicationTests {
+class LotteryBuyerApplicationTests {
 
     @Test
     void contextLoads() {


### PR DESCRIPTION
이번 PR 은 프로젝트 명칭 변경 관련 작업이다.

같은 의미임에도 보다 간결한 단어로 변경했다. (`lottery-purchaser -> lottery-buyer`)
동행복권 사이트도 buy 를 사용하기도 하고, (일치감)
코드 작성 시, 긴 단어 보다는 짧은 단어가 보다 편하기 때문이다.

This closes #20 